### PR TITLE
Antishiny toggle

### DIFF
--- a/scripts/background.css
+++ b/scripts/background.css
@@ -20,6 +20,10 @@ img {
     -moz-animation: spin linear 5s infinite;
 }
 
+.anti {
+    filter: invert(1);
+}
+
 .wailordnone {
     image-rendering: crisp-edges;
     max-width: 500px;

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -8,7 +8,10 @@ const config = {
     swarmOdds: 1 / 64,
     fakemonOdds: 1 / 128, // Chance to add a single "fakemon" from Smogon's CAP - https://www.smogon.com/dex/ss/formats/cap/
     bigWailords: true, // BIG FUCKINF WAILORD
-    sphealSpin: true // Spinny boi
+    sphealSpin: true, // Spinny boi
+    antiShiny: false, // Enables the chance for an anti shiny Pokémon to appear
+    antiShinySplit: true, // Enables shiny Pokémon having a 50% chance of appearing as an anti shiny, if disabled uses antiOdds instead
+    antiOdds: 1 / 128 // Odds of an anti shiny Pokémon appearing if antiShinySplit is false
 };
 
 // Create background elements on load
@@ -48,7 +51,26 @@ function create() {
         }
 
         const isShiny = Math.random() < config.shinyOdds;
-        const sparkleClass = isShiny ? "sparkle" : "none";
+        if(config.antiShiny)
+        {
+            const isAnti = Math.random() < config.antiOdds;
+            if(config.antiShinySplit && Math.random() < 0.5)
+            {
+                sparkleColor = isShiny ? "anti" : "none";
+            }
+            else if(!config.antiShinySplit && !isShiny)
+            {
+                sparkleColor = isAnti ? "anti" : "none";
+            }
+            else
+            {
+                sparkleColor = isShiny ? "sparkle" : "none";
+            }
+        }
+        else{
+            sparkleColor = isShiny ? "sparkle" : "none";
+        }
+        const sparkleClass = sparkleColor
         const spritePath = isShiny ? "shiny/" : "normal/";
         const area = floating_pokemon.includes(form) ? "sky" : "ground";
 
@@ -108,21 +130,38 @@ function randomOrder() {
             `;
 
             // Add sparkle images
-            if (sprite.classList.contains("sparkle") || sprite.classList.contains("wailordsparkle")) {
+            if (sprite.classList.contains("sparkle") || sprite.classList.contains("wailordsparkle") || sprite.classList.contains("anti")) {
                 const offset = sprite.offsetWidth / 6;
                 const sparkleSize = sprite.offsetWidth * 1.3;
                 const sparkleMaxSize = sprite.classList.contains("wailordsparkle") ? 1000 : 150;
 
-                sparklesHTML += `
-                    <img style="--x-position: ${x + (sprite.classList.contains("wailordsparkle") ? offset : -offset)}px; 
-                                 --y-position: ${y - offset}px; 
-                                 z-index: -1; width: ${sparkleSize}px; 
-                                 max-height: ${sparkleMaxSize}px; max-width: ${sparkleMaxSize}px;" 
-                         src="./sprites/sparkles.gif" 
-                         onerror="this.style.display='none'" 
-                         alt="Sparkle">
-                `;
-            }
+                if(sprite.classList.contains("anti"))
+                    {
+                        sparklesHTML += `
+                        <img style="--x-position: ${x + (sprite.classList.contains("wailordanti") ? offset : -offset)}px; 
+                                     --y-position: ${y - offset}px; 
+                                     z-index: 1; width: ${sparkleSize}px; 
+                                     max-height: ${sparkleMaxSize}px; max-width: ${sparkleMaxSize}px; 
+                                     filter: invert(1)" 
+                             src="./sprites/sparkles.gif" 
+                             class="sparklegif" 
+                             onerror="this.style.display='none'" 
+                             alt="Sparkle">
+                    `;   
+                    }
+                    else{
+                    sparklesHTML += `
+                        <img style="--x-position: ${x + (sprite.classList.contains("wailordsparkle") ? offset : -offset)}px; 
+                                     --y-position: ${y - offset}px; 
+                                     z-index: 1; width: ${sparkleSize}px; 
+                                     max-height: ${sparkleMaxSize}px; max-width: ${sparkleMaxSize}px;" 
+                             src="./sprites/sparkles.gif" 
+                             class="sparklegif" 
+                             onerror="this.style.display='none'" 
+                             alt="Sparkle">
+                    `;
+                    }
+                }
         });
     }
 


### PR DESCRIPTION
Adds a few config options:

- `antiShiny`
  - Toggle for anti shiny Pokemon appearing
- `antiShinySplit`
  - 50% chance to replace a shiny with an anti shiny, if disabled uses `antiOdds` instead
- `antiOdds`
  - Identical to `shinyOdds`

This was something I meant to do a while ago but got side tracked working on the canon sizes instead. 
![Screenshot_20241116_231636](https://github.com/user-attachments/assets/abc25442-c9cc-4976-add0-b533218127bb)
